### PR TITLE
Added a direct include file for using the classifier

### DIFF
--- a/ATL24_coastnet/coastnet.h
+++ b/ATL24_coastnet/coastnet.h
@@ -388,7 +388,7 @@ T box_filter (const T &p, const int filter_width)
 }
 
 template<typename T>
-std::vector<double> get_elevation_estimates (const T &p, const double sigma, const unsigned cls)
+std::vector<double> get_elevation_estimates (T p, const double sigma, const unsigned cls)
 {
     using namespace std;
 
@@ -483,24 +483,6 @@ T classify (const bool verbose, T p, const std::string &model_filename, const bo
 {
     using namespace std;
     using namespace ATL24_coastnet;
-
-    // Get indexes into p
-    vector<size_t> sorted_indexes (p.size ());
-
-    // 0, 1, 2, ...
-    iota (sorted_indexes.begin (), sorted_indexes.end (), 0);
-
-    // Sort indexes by X
-    sort (sorted_indexes.begin (), sorted_indexes.end (),
-        [&](const auto &a, const auto &b)
-        { return p[a].x < p[b].x; });
-
-    // Sort points by X
-    {
-    auto tmp (p);
-    for (size_t i = 0; i < sorted_indexes.size (); ++i)
-        p[i] = tmp[sorted_indexes[i]];
-    }
 
     // Save the predictions
     vector<unsigned> q (p.size ());
@@ -600,13 +582,6 @@ T classify (const bool verbose, T p, const std::string &model_filename, const bo
 
     if (verbose)
         clog << "used predictions = " << 100.0 * used_predictions / p.size () << "%" << endl;
-
-    // Restore original order
-    {
-    auto tmp (p);
-    for (size_t i = 0; i < sorted_indexes.size (); ++i)
-        p[sorted_indexes[i]] = tmp[i];
-    }
 
     return p;
 }

--- a/ATL24_coastnet/coastnet.h
+++ b/ATL24_coastnet/coastnet.h
@@ -715,8 +715,8 @@ template<typename T>
 class features
 {
     public:
-    explicit features (const T &dataset)
-        : dataset (dataset)
+    explicit features (const T &_dataset)
+        : dataset (_dataset)
     {
     }
     size_t size () const

--- a/ATL24_coastnet/custom_dataset.h
+++ b/ATL24_coastnet/custom_dataset.h
@@ -29,20 +29,20 @@ class coastnet_dataset
 
     public:
     coastnet_dataset (const std::vector<std::string> &fns,
-        const size_t patch_rows,
-        const size_t patch_cols,
-        const double aspect_ratio,
-        const augmentation_params &ap,
-        const bool ap_enabled,
+        const size_t init_patch_rows,
+        const size_t init_patch_cols,
+        const double init_aspect_ratio,
+        const augmentation_params &init_ap,
+        const bool init_ap_enabled,
         const size_t samples_per_class,
         const bool verbose,
-        RNG &rng)
-        : patch_rows (patch_rows)
-        , patch_cols (patch_cols)
-        , aspect_ratio (aspect_ratio)
-        , ap (ap)
-        , ap_enabled (ap_enabled)
-        , rng (rng)
+        RNG &init_rng)
+        : patch_rows (init_patch_rows)
+        , patch_cols (init_patch_cols)
+        , aspect_ratio (init_aspect_ratio)
+        , ap (init_ap)
+        , ap_enabled (init_ap_enabled)
+        , rng (init_rng)
     {
         using namespace std;
 

--- a/ATL24_coastnet/pgm.h
+++ b/ATL24_coastnet/pgm.h
@@ -15,9 +15,9 @@ struct header
 {
     header () : w (0), h (0)
     { }
-    header (const size_t w, const size_t h)
-        : w (w)
-        , h (h)
+    header (const size_t init_w, const size_t init_h)
+        : w (init_w)
+        , h (init_h)
     { }
     size_t w; // Width of image in pixels
     size_t h; // Height of images in pixels

--- a/ATL24_coastnet/utils.h
+++ b/ATL24_coastnet/utils.h
@@ -5,7 +5,7 @@
 
 const std::string PI_NAME ("index_ph");
 const std::string X_NAME ("x_atc");
-const std::string Z_NAME ("ortho_h");
+const std::string Z_NAME ("geoid_corr_h");
 
 #ifndef PREDICTION_NAME
 #define PREDICTION_NAME "prediction"
@@ -93,7 +93,7 @@ void write_point2d (std::ostream &os, const T &p)
     const auto pr = os.precision ();
 
     // Print along-track meters
-    os << "index_ph,x_atc,ortho_h,manual_label" << endl;
+    os << "index_ph,x_atc,geoid_corr_h,manual_label" << endl;
     for (size_t i = 0; i < p.size (); ++i)
     {
         // Write the index
@@ -120,7 +120,7 @@ void write_classified_point2d (std::ostream &os, const T &p)
     const auto pr = os.precision ();
 
     // Print along-track meters
-    os << "index_ph,x_atc,ortho_h,manual_label,prediction,sea_surface_h,bathy_h" << endl;
+    os << "index_ph,x_atc,geoid_corr_h,manual_label,prediction,sea_surface_h,bathy_h" << endl;
     for (size_t i = 0; i < p.size (); ++i)
     {
         // Write the index
@@ -361,7 +361,7 @@ std::vector<ATL24_coastnet::classified_point2d> convert_dataframe (
     if (x_it == headers.end ())
         throw runtime_error ("Can't find 'x_atc' in dataframe");
     if (z_it == headers.end ())
-        throw runtime_error ("Can't find 'ortho_h' in dataframe");
+        throw runtime_error ("Can't find 'geoid_corr_h' in dataframe");
 
     has_manual_label = cls_it != headers.end ();
     has_predictions = prediction_it != headers.end ();

--- a/ATL24_coastnet/utils.h
+++ b/ATL24_coastnet/utils.h
@@ -84,45 +84,6 @@ class prediction_cache
     };
 };
 
-std::vector<ATL24_coastnet::classified_point2d> read_classified_point2d (std::istream &is)
-{
-    using namespace std;
-
-    string line;
-
-    // Get the column labels
-    getline (is, line);
-
-    vector<classified_point2d> p;
-    while (getline (is, line))
-    {
-        stringstream ss (line);
-        size_t h5_index;
-        ss >> h5_index;
-        ss.get (); // ignore ','
-        double x;
-        ss >> x;
-        ss.get (); // ignore ','
-        double z;
-        ss >> z;
-        ss.get (); // ignore ','
-        size_t cls;
-        ss >> cls;
-        ss.get (); // ignore ','
-        size_t prediction;
-        ss >> prediction;
-        ss.get (); // ignore ','
-        double surface_elevation;
-        ss >> surface_elevation;
-        p.push_back (classified_point2d {h5_index, x, z, cls, prediction, surface_elevation});
-        double bathy_elevation;
-        ss >> bathy_elevation;
-        p.push_back (classified_point2d {h5_index, x, z, cls, prediction, bathy_elevation});
-    }
-
-    return p;
-}
-
 template<typename T>
 void write_point2d (std::ostream &os, const T &p)
 {
@@ -224,16 +185,6 @@ template<typename T>
 point2d_extents get_extents (const T &p)
 {
     return get_extents (p, 0, p.size ());
-}
-
-std::pair<size_t,size_t> get_grid_location (const auto &p,
-    const auto &minp,
-    const double x_resolution,
-    const double z_resolution)
-{
-    const size_t row = (p.z - minp.z) / z_resolution;
-    const size_t col = (p.x - minp.x) / x_resolution;
-    return std::make_pair (row, col);
 }
 
 struct augmentation_params

--- a/ATL24_coastnet/xgboost.h
+++ b/ATL24_coastnet/xgboost.h
@@ -92,8 +92,8 @@ class dmatrix
 class xgbooster
 {
     public:
-    explicit xgbooster (const bool _verbose)
-        : verbose (_verbose)
+    explicit xgbooster (const bool init_verbose)
+        : verbose (init_verbose)
         , initialized (false)
         , trained (false)
     {

--- a/ATL24_coastnet/xgboost.h
+++ b/ATL24_coastnet/xgboost.h
@@ -92,8 +92,8 @@ class dmatrix
 class xgbooster
 {
     public:
-    explicit xgbooster (const bool verbose)
-        : verbose (verbose)
+    explicit xgbooster (const bool _verbose)
+        : verbose (_verbose)
         , initialized (false)
         , trained (false)
     {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(CCACHE_PROGRAM)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif()
 
-set(CMAKE_CXX_FLAGS "-Wall -Werror ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall -Werror -Wshadow ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 
 include_directories(${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/ATL24_coastnet)
 

--- a/apps/blunder_detection.cpp
+++ b/apps/blunder_detection.cpp
@@ -47,7 +47,7 @@ int main (int argc, char **argv)
         // Convert it to the correct format
         bool has_manual_label = false;
         bool has_predictions = false;
-        auto p = convert_dataframe (df, has_manual_label, has_predictions);
+        const auto p = convert_dataframe (df, has_manual_label, has_predictions);
 
         if (args.verbose)
             clog << p.size () << " points read" << endl;
@@ -55,8 +55,11 @@ int main (int argc, char **argv)
         if (has_predictions == false)
             throw runtime_error ("Expected the dataframe to have predictions, but none were found");
 
-        // Get indexes into p
-        vector<size_t> sorted_indexes (p.size ());
+        // Copy points
+        auto q (p);
+
+        // Get indexes into q
+        vector<size_t> sorted_indexes (q.size ());
 
         // 0, 1, 2, ...
         iota (sorted_indexes.begin (), sorted_indexes.end (), 0);
@@ -64,49 +67,36 @@ int main (int argc, char **argv)
         // Sort indexes by X
         sort (sorted_indexes.begin (), sorted_indexes.end (),
             [&](const auto &a, const auto &b)
-            { return p[a].x < p[b].x; });
+            { return q[a].x < q[b].x; });
 
         // Sort points by X
         {
-        auto tmp (p);
+        auto tmp (q);
         for (size_t i = 0; i < sorted_indexes.size (); ++i)
-            p[i] = tmp[sorted_indexes[i]];
+            q[i] = tmp[sorted_indexes[i]];
         }
 
         if (args.verbose)
             clog << "Getting surface and bathy estimates" << endl;
 
         // Compute surface and bathy estimates
-        const auto s = get_surface_estimates (p, args.surface_sigma);
-        const auto b = get_bathy_estimates (p, args.bathy_sigma);
+        const auto s = get_surface_estimates (q, args.surface_sigma);
+        const auto b = get_bathy_estimates (q, args.bathy_sigma);
 
-        assert (s.size () == p.size ());
-        assert (b.size () == p.size ());
+        assert (s.size () == q.size ());
+        assert (b.size () == q.size ());
 
         // Assign surface and bathy estimates
-        for (size_t j = 0; j < p.size (); ++j)
+        for (size_t j = 0; j < q.size (); ++j)
         {
-            p[j].surface_elevation = s[j];
-            p[j].bathy_elevation = b[j];
+            q[j].surface_elevation = s[j];
+            q[j].bathy_elevation = b[j];
         }
 
         if (args.verbose)
             clog << "Re-classifying points" << endl;
 
-        auto q = blunder_detection (p, args);
-
-        // Check logic
-        assert (p.size () == q.size ());
-
-        if (args.verbose)
-        {
-            size_t changed = 0;
-
-            for (size_t i = 0; i < p.size (); ++i)
-                if (p[i].prediction != q[i].prediction)
-                    ++changed;
-            clog << changed << " point classifications changed" << endl;
-        }
+        q = blunder_detection (q, args);
 
         // Restore original order
         {
@@ -114,6 +104,11 @@ int main (int argc, char **argv)
         for (size_t i = 0; i < sorted_indexes.size (); ++i)
             q[sorted_indexes[i]] = tmp[i];
         }
+
+        // Ensure photon order did not change
+#pragma omp parallel for
+        for ([[maybe_unused]] size_t i = 0; i < q.size (); ++i)
+            assert (p[i].h5_index == q[i].h5_index);
 
         // Write re-classified output to stdout
         write_classified_point2d (cout, q);

--- a/apps/classify.cpp
+++ b/apps/classify.cpp
@@ -2,6 +2,7 @@
 #include "coastnet.h"
 #include "dataframe.h"
 #include "utils.h"
+#include "classify_cmd.h"
 
 const std::string usage {"classify [options] < filename.csv"};
 
@@ -46,7 +47,7 @@ int main (int argc, char **argv)
             clog << p.size () << " points read" << endl;
 
         // Classify them
-        const auto q = classify (p, args);
+        const auto q = classify (args.verbose, p, args.model_filename, args.use_predictions);
         assert (q.size () == p.size ());
 
         // Ensure photon order did not change

--- a/apps/classify.cpp
+++ b/apps/classify.cpp
@@ -1,4 +1,4 @@
-#include "classify_cmd.h"
+#include "cmd_utils.h"
 #include "coastnet.h"
 #include "dataframe.h"
 #include "utils.h"

--- a/apps/classify_cmd.h
+++ b/apps/classify_cmd.h
@@ -1,7 +1,7 @@
 #ifndef CMD_H
 #define CMD_H
 
-#include "../ATL24_coastnet/cmd_utils.h"
+#include "ATL24_coastnet/cmd_utils.h"
 
 namespace ATL24_coastnet
 {
@@ -14,10 +14,8 @@ struct args
     bool help = false;
     bool verbose = false;
     bool use_predictions = false;
-    bool get_results = false;
     size_t num_classes = 5;
     std::string model_filename = std::string ("./coastnet_model.pt");
-    std::string results_filename = std::string ("./coastnet_results.txt");
 };
 
 std::ostream &operator<< (std::ostream &os, const args &args)
@@ -26,10 +24,8 @@ std::ostream &operator<< (std::ostream &os, const args &args)
     os << "help: " << args.help << std::endl;
     os << "verbose: " << args.verbose << std::endl;
     os << "use_predictions: " << args.use_predictions << std::endl;
-    os << "get-results: " << args.get_results << std::endl;
     os << "num-classes: " << args.num_classes << std::endl;
     os << "model-filename: " << args.model_filename << std::endl;
-    os << "results-filename: " << args.results_filename << std::endl;
     return os;
 }
 
@@ -43,14 +39,12 @@ args get_args (int argc, char **argv, const std::string &usage)
             {"help", no_argument, 0,  'h' },
             {"verbose", no_argument, 0,  'v' },
             {"use-predictions", no_argument, 0,  'p' },
-            {"get-results", no_argument, 0,  'g' },
             {"num-classes", required_argument, 0,  'c' },
             {"model-filename", required_argument, 0,  'f' },
-            {"results-filename", required_argument, 0,  'r' },
             {0,      0,           0,  0 }
         };
 
-        int c = getopt_long(argc, argv, "hvpc:f:r:", long_options, &option_index);
+        int c = getopt_long(argc, argv, "hvpc:f:", long_options, &option_index);
         if (c == -1)
             break;
 
@@ -68,10 +62,8 @@ args get_args (int argc, char **argv, const std::string &usage)
             }
             case 'v': args.verbose = true; break;
             case 'p': args.use_predictions = true; break;
-            case 'g': args.get_results = true; break;
             case 'c': args.num_classes = atol(optarg); break;
             case 'f': args.model_filename = std::string(optarg); break;
-            case 'r': args.results_filename = std::string(optarg); break;
         }
     }
 

--- a/apps/classify_cmd.h
+++ b/apps/classify_cmd.h
@@ -14,6 +14,7 @@ struct args
     bool help = false;
     bool verbose = false;
     bool use_predictions = false;
+    bool get_results = false;
     size_t num_classes = 5;
     std::string model_filename = std::string ("./coastnet_model.pt");
     std::string results_filename = std::string ("./coastnet_results.txt");
@@ -25,6 +26,7 @@ std::ostream &operator<< (std::ostream &os, const args &args)
     os << "help: " << args.help << std::endl;
     os << "verbose: " << args.verbose << std::endl;
     os << "use_predictions: " << args.use_predictions << std::endl;
+    os << "get-results: " << args.get_results << std::endl;
     os << "num-classes: " << args.num_classes << std::endl;
     os << "model-filename: " << args.model_filename << std::endl;
     os << "results-filename: " << args.results_filename << std::endl;
@@ -41,6 +43,7 @@ args get_args (int argc, char **argv, const std::string &usage)
             {"help", no_argument, 0,  'h' },
             {"verbose", no_argument, 0,  'v' },
             {"use-predictions", no_argument, 0,  'p' },
+            {"get-results", no_argument, 0,  'g' },
             {"num-classes", required_argument, 0,  'c' },
             {"model-filename", required_argument, 0,  'f' },
             {"results-filename", required_argument, 0,  'r' },
@@ -65,6 +68,7 @@ args get_args (int argc, char **argv, const std::string &usage)
             }
             case 'v': args.verbose = true; break;
             case 'p': args.use_predictions = true; break;
+            case 'g': args.get_results = true; break;
             case 'c': args.num_classes = atol(optarg); break;
             case 'f': args.model_filename = std::string(optarg); break;
             case 'r': args.results_filename = std::string(optarg); break;

--- a/apps/classify_cmd.h
+++ b/apps/classify_cmd.h
@@ -1,7 +1,7 @@
 #ifndef CMD_H
 #define CMD_H
 
-#include "cmd_utils.h"
+#include "../ATL24_coastnet/cmd_utils.h"
 
 namespace ATL24_coastnet
 {

--- a/apps/classify_inc.h
+++ b/apps/classify_inc.h
@@ -1,0 +1,4 @@
+#include "../ATL24_coastnet/coastnet.h"
+#include "../ATL24_coastnet/raster.h"
+#include "../ATL24_coastnet/utils.h"
+#include "classify_cmd.h"

--- a/apps/classify_inc.h
+++ b/apps/classify_inc.h
@@ -1,4 +1,0 @@
-#include "../ATL24_coastnet/coastnet.h"
-#include "../ATL24_coastnet/raster.h"
-#include "../ATL24_coastnet/utils.h"
-#include "classify_cmd.h"

--- a/scores.txt
+++ b/scores.txt
@@ -6,9 +6,9 @@ Average cal_F1 = 0.900
 Average Weighted F1 = 0.935
 Average Weighted cal_F1 = 0.893
 Bathy
-Average Acc = 0.965
-Average F1 = 0.812
-Average BA = 0.926
+Average Acc = 0.982
+Average F1 = 0.664
+Average BA = 0.921
 Average cal_F1 = 0.900
 Average Weighted F1 = 0.935
 Average Weighted cal_F1 = 0.893

--- a/scores.txt
+++ b/scores.txt
@@ -1,0 +1,14 @@
+Surface
+Average Acc = 0.948
+Average F1 = 0.960
+Average BA = 0.931
+Average cal_F1 = 0.900
+Average Weighted F1 = 0.935
+Average Weighted cal_F1 = 0.893
+Bathy
+Average Acc = 0.965
+Average F1 = 0.812
+Average BA = 0.926
+Average cal_F1 = 0.900
+Average Weighted F1 = 0.935
+Average Weighted cal_F1 = 0.893

--- a/scores_checked.txt
+++ b/scores_checked.txt
@@ -1,0 +1,14 @@
+Checked Surface
+Average Acc = 0.948
+Average F1 = 0.960
+Average BA = 0.931
+Average cal_F1 = 0.900
+Average Weighted F1 = 0.936
+Average Weighted cal_F1 = 0.893
+Checked Bathy
+Average Acc = 0.984
+Average F1 = 0.671
+Average BA = 0.903
+Average cal_F1 = 0.876
+Average Weighted F1 = 0.936
+Average Weighted cal_F1 = 0.893

--- a/scores_xval.txt
+++ b/scores_xval.txt
@@ -1,0 +1,14 @@
+Surface
+Average Acc = 0.936
+Average F1 = 0.950
+Average BA = 0.923
+Average cal_F1 = 0.889
+Average Weighted F1 = 0.925
+Average Weighted cal_F1 = 0.882
+Bathy
+Average Acc = 0.981
+Average F1 = 0.657
+Average BA = 0.892
+Average cal_F1 = 0.860
+Average Weighted F1 = 0.925
+Average Weighted cal_F1 = 0.882

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -11,5 +11,5 @@ echo build = ${build}
 
 find $1 | \
     parallel --verbose --lb --jobs=15 \
-        "build/${build}/blunder_detection \
+        "build/${build}/blunder_detection --verbose \
         < {} > $2/{/.}_checked.csv"

--- a/scripts/classify.sh
+++ b/scripts/classify.sh
@@ -8,6 +8,6 @@ mkdir -p predictions
 for n in $(seq 0 4)
 do
     parallel --lb --dry-run \
-        "build/release/classify --verbose --num-classes=7 --model-filename=coastnet_model-${n}.json --results-filename=predictions/{/.}_results-${n}.txt < {} > predictions/{/.}_classified_${n}.csv" \
+        "build/release/classify --verbose --num-classes=7 --model-filename=coastnet_model-${n}.json < {} > predictions/{/.}_classified_${n}.csv" \
         :::: coastnet_test_files-${n}.txt
 done

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -22,12 +22,12 @@ def preprocess(verbose,
         print(f'Read {total} photons')
 
     # Filter out photons
-    df = df[df['ortho_h'] > min_elevation]
+    df = df[df['geoid_corr_h'] > min_elevation]
 
     if verbose:
         print(f'Filtered {total - len(df)} photons')
 
-    df = df[df['ortho_h'] < max_elevation]
+    df = df[df['geoid_corr_h'] < max_elevation]
 
     if verbose:
         print(f'Filtered {total - len(df)} photons')

--- a/tests/test_dataframe.cpp
+++ b/tests/test_dataframe.cpp
@@ -66,7 +66,6 @@ dataframe get_random_dataframe (const size_t cols, const size_t rows)
     df.set_rows (rows);
 
     // Set the data to random numbers
-    mt19937 rng(12345);
     std::uniform_real_distribution<> d(1.0, 100.0);
     for (const auto &name : df.get_headers ())
         for (size_t i = 0; i < rows; ++i)

--- a/tests/test_pgm.cpp
+++ b/tests/test_pgm.cpp
@@ -28,10 +28,10 @@ void test_bad_headers ()
     }
     {
         // Wrong maxsize
-        stringstream s;
-        s.str ("P5\n1 1\n255555\n");
+        stringstream tmp_s;
+        tmp_s.str ("P5\n1 1\n255555\n");
         bool failed = false;
-        try { h = read_header (s); }
+        try { h = read_header (tmp_s); }
         catch (...) { failed = true; }
         VERIFY (failed);
     }


### PR DESCRIPTION
__Purpose__

To directly include the CoastNet classifier header from the sliderule code

__Changes__

* Some #include directives were modified so that relative paths were consistently used.  Reason: with in the sliderule build the same compilation unit will include both this classifier and other classifiers that have the exact same header filenames; this makes it difficult to set global include paths - evne if they are separated out when included from sliderule code, the locally included files are no longer able to be found

* Fixed all occurrences of an aliased variable.  Reason: sliderule builds enforce strict policies on compiler warnings (sometimes annoyingly so, but we've committed to it and it pays off).

* Added a `get_results` argument and conditioned the code in the classify function that generates and writes out the results to the argument.  Reasion: the code is unnecessary when executing in the production environment.

* Removed the `read_classified_point2d` function and `get_grid_location` function.  Both appear to be dead code and were causing compiler/static analysis warnings. 
